### PR TITLE
[Systray] Use function pointers to better handle lifetime

### DIFF
--- a/Systray.UnitTests/TrayIconUnitTests.cs
+++ b/Systray.UnitTests/TrayIconUnitTests.cs
@@ -111,10 +111,9 @@ public class TrayIconUnitTests : IDisposable
         Assert.Single(messages);
         Assert.Equal(NOTIFY_ICON_MESSAGE.NIM_ADD, messages[0].Message);
 
-        // The window subclass should still have been created, but should be disposed.
-        Assert.True(wasSubclassCalled);
-        Assert.NotNull(mockHandler.WndProcDelegate);
-        Assert.True(mockHandler.IsDisposed);
+        // The window subclass should not have been created yet.
+        Assert.False(wasSubclassCalled);
+        Assert.Null(mockHandler.WndProcDelegate);
     }
 
     [Fact]

--- a/systray/TrayIcon.cs
+++ b/systray/TrayIcon.cs
@@ -128,21 +128,30 @@ public class TrayIcon
         Guid = guid;
         OwnerHwnd = ownerHwnd;
 
-        if (shouldHandleMessages)
+        try
         {
-            _windowSubclassHandler = WindowSubclassHandlerFactoryFn(ownerHwnd, HandleMessage);
+            if (shouldHandleMessages)
+            {
+                _windowSubclassHandler = WindowSubclassHandlerFactoryFn(ownerHwnd, HandleMessage);
 
-            // RegisterWindowMessage is global, so it's probably not the *best*
-            // idea to take one of these slots, but opinions seem mixed.
-            //
-            // Against: https://stackoverflow.com/questions/4406909/using-wm-user-wm-app-or-registerwindowmessage
-            // For: http://www.flounder.com/messages.htm
-            // See also: https://stackoverflow.com/questions/30843497/wm-user-vs-wm-app
-            callbackMessage ??= PInvokeSystray.RegisterWindowMessage($"TrayIconMessage-{Guid}");
+                // RegisterWindowMessage is global, so it's probably not the *best*
+                // idea to take one of these slots, but opinions seem mixed.
+                //
+                // Against: https://stackoverflow.com/questions/4406909/using-wm-user-wm-app-or-registerwindowmessage
+                // For: http://www.flounder.com/messages.htm
+                // See also: https://stackoverflow.com/questions/30843497/wm-user-vs-wm-app
+                callbackMessage ??= PInvokeSystray.RegisterWindowMessage($"TrayIconMessage-{Guid}");
+            }
+            CallbackMessage = callbackMessage;
+
+            Create();
         }
-        CallbackMessage = callbackMessage;
-
-        Create();
+        catch
+        {
+            // If we failed to create the icon, dispose the WindowSubclass
+            _windowSubclassHandler?.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/systray/TrayIcon.cs
+++ b/systray/TrayIcon.cs
@@ -128,29 +128,25 @@ public class TrayIcon
         Guid = guid;
         OwnerHwnd = ownerHwnd;
 
-        try
+        if (shouldHandleMessages)
         {
-            if (shouldHandleMessages)
-            {
-                _windowSubclassHandler = WindowSubclassHandlerFactoryFn(ownerHwnd, HandleMessage);
-
-                // RegisterWindowMessage is global, so it's probably not the *best*
-                // idea to take one of these slots, but opinions seem mixed.
-                //
-                // Against: https://stackoverflow.com/questions/4406909/using-wm-user-wm-app-or-registerwindowmessage
-                // For: http://www.flounder.com/messages.htm
-                // See also: https://stackoverflow.com/questions/30843497/wm-user-vs-wm-app
-                callbackMessage ??= PInvokeSystray.RegisterWindowMessage($"TrayIconMessage-{Guid}");
-            }
-            CallbackMessage = callbackMessage;
-
-            Create();
+            // RegisterWindowMessage is global, so it's probably not the *best*
+            // idea to take one of these slots, but opinions seem mixed.
+            //
+            // Against: https://stackoverflow.com/questions/4406909/using-wm-user-wm-app-or-registerwindowmessage
+            // For: http://www.flounder.com/messages.htm
+            // See also: https://stackoverflow.com/questions/30843497/wm-user-vs-wm-app
+            callbackMessage ??= PInvokeSystray.RegisterWindowMessage($"TrayIconMessage-{Guid}");
         }
-        catch
+        CallbackMessage = callbackMessage;
+
+        Create();
+
+        if (shouldHandleMessages)
         {
-            // If we failed to create the icon, dispose the WindowSubclass
-            _windowSubclassHandler?.Dispose();
-            throw;
+            // Create can fail (e.g. if the GUID is already in use). So don't
+            // subclass the window until Create succeeds.
+            _windowSubclassHandler = WindowSubclassHandlerFactoryFn(ownerHwnd, HandleMessage);
         }
     }
 

--- a/systray_doom/Program.cs
+++ b/systray_doom/Program.cs
@@ -144,7 +144,8 @@ bool TryDisplayContextMenuRaw(HWND hwnd, Systray.PhysicalPoint pt)
 
         // TODO: return focus to systray after dismissing the menu. This line
         // doesn't work:
-        trayIcon.Focus();
+        //
+        // trayIcon.Focus();
     }
     finally
     {
@@ -252,7 +253,7 @@ var windowProcHelper = new WindowMessageHandler((hwnd, msg, wParam, lParam) =>
                 PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_HIDE);
 
                 // TODO: doesn't work.
-                trayIcon.Focus();
+                // trayIcon.Focus();
             }
             else
             {

--- a/systray_doom/WindowMessageHandler.cs
+++ b/systray_doom/WindowMessageHandler.cs
@@ -42,6 +42,11 @@ internal class WindowMessageHandler
         }
     }
 
+    /// <summary>
+    /// A delegate to handle window messages.
+    ///
+    /// If you return null, the default window procedure will be called.
+    /// </summary>
     internal delegate LRESULT? WndProcDelegate(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam);
 
     public struct Data
@@ -54,6 +59,22 @@ internal class WindowMessageHandler
     private static readonly Dictionary<int, WeakReference<WindowMessageHandler>> s_handlers = [];
     private static int s_nextId = 1;
 
+    /// <summary>
+    /// WindowMessageHandler makes it simpler to write non-static WndProc
+    /// functions.
+    ///
+    /// 1. When you create your `WNDCLASSEXW`, set `lpfnWndProc` to
+    /// `WindowMessageHandler.StaticWndProc`.
+    ///
+    /// 2. When you call `CreateWindowEx`, set `lpParam` to an instance of
+    /// `WindowMessageHandler`.
+    ///
+    /// Your window messages will be routed to your delegate!
+    ///
+    /// IMPORTANT: this instance must last as long as the HWND. If it does not,
+    /// the window will not crash, but it will no longer call your delegate.
+    /// </summary>
+    /// <param name="deleg">A delegate to handle window messages</param>
     public WindowMessageHandler(WndProcDelegate deleg)
     {
         _data = new Data

--- a/systray_doom/WindowMessageHandler.cs
+++ b/systray_doom/WindowMessageHandler.cs
@@ -26,11 +26,14 @@ internal class WindowMessageHandler
                     var data = (Data*)PInvoke.GetWindowLongPtr(hwnd, WINDOW_LONG_PTR_INDEX.GWLP_USERDATA);
                     if (data != null)
                     {
-                        var that = Marshal.GetDelegateForFunctionPointer<WndProcDelegate>(data->WndProcDelegate);
-                        var result = that(hwnd, msg, wParam, lParam);
-                        if (result != null)
+                        var id = data->ID;
+                        if (s_handlers.TryGetValue(id, out var weakRef) && weakRef.TryGetTarget(out WindowMessageHandler? that))
                         {
-                            return result.Value;
+                            var result = that?._wndProc(hwnd, msg, wParam, lParam);
+                            if (result != null)
+                            {
+                                return result.Value;
+                            }
                         }
                     }
                 }
@@ -43,21 +46,22 @@ internal class WindowMessageHandler
 
     public struct Data
     {
-        public nint WndProcDelegate;
+        public int ID;
     }
     private Data _data;
-
     private readonly WndProcDelegate _wndProc;
 
-    public WindowMessageHandler(WndProcDelegate del)
+    private static readonly Dictionary<int, WeakReference<WindowMessageHandler>> s_handlers = [];
+    private static int s_nextId = 1;
+
+    public WindowMessageHandler(WndProcDelegate deleg)
     {
-        // https://github.com/ControlzEx/ControlzEx/blob/cbb56cab39ffc78d9599208826f47eeab70455f7/src/ControlzEx/Controls/GlowWindow.cs#L94
-        _wndProc = del;
-        var delPtr = Marshal.GetFunctionPointerForDelegate(del);
         _data = new Data
         {
-            WndProcDelegate = delPtr,
+            ID = s_nextId++,
         };
+        _wndProc = deleg;
+        s_handlers[_data.ID] = new WeakReference<WindowMessageHandler>(this, trackResurrection: false);
     }
 
     // Pass this to the WNDCLASS.lpParam field in CreateWindowEx.


### PR DESCRIPTION
Today, if your `TrayIcon` or `WindowSubclassHandler` goes out of scope before its HWND, the HWND will crash because the subclass WndProc goes out of scope. This change updates these components to avoid crashing in cases like this *and* to make creation more reliable.

This issue occurs reliably if trying to create a duplicate `TrayIcon` (identical GUIDs). The creation step, which occurs after subclassing, will fail, causing the TrayIcon & its subclass handler to be destroyed, leading to a crash when the window next receives a WM.

## What changed?

* Refactor `WindowSubclassHandler` to use a static WndProc function. It now maintains a static mapping of HWNDs to (weak references to) handlers, calling the appropriate handler as necessary.
* Update `TrayIcon` to create the window handler *only* after successfully creating the icon.
* Update `WindowMessageHandler` (what I use for WndProcs in the main test app) to similarly call a static method & hand off via a dictionary.
* Disable calls to `.Focus()`, which now seem to crash
* Add unit test.

## How tested?

* [x] Launching the Doom app still works.
* [x] Context menu still works.
* [x] Hiding & showing the app works several times.
* [x] Closing the app still works.
* [x] Launching a second instance of Doom continues to fail without affecting the existing instance.
* [x] Unit tests pass.

---

Thanks to Kit Hymel & Jevan Saks.