### PR TITLE
Adopt Nerdbank.GitVersioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## CURRENT
 * META: Add AGENTS.md for guiding agents.
 * META: Add basic PR validation.
+* META: Adopt Nerdbank.GitVersioning with shared configuration and remove hard-coded package version.
+* META: Document versioning flow, including the `dev` prerelease suffix and future automation follow-up.
 
 ## v0.1.3
 * BUG: Fixed an issue where construction failures in `TrayIcon` crashed the host HWND.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ $apiKey = # paste from the website
 git checkout main
 git merge dev
 
-# Bump the version
-# In systray.csproj, bump `<Version>`.
+# Confirm the base version
+# Update version.json's `"version"` field if you need to change the major/minor/patch.
+# Nerdbank.GitVersioning automatically calculates the 4th component based on git height.
 
 # Update the CHANGELOG
 # ...
@@ -77,6 +78,12 @@ dotnet nuget push .\Systray\bin\Release\citelao.SystrayIcon.0.1.0.1.nupkg --api-
 # Dummy Nuget:
 # dotnet nuget push .\Systray\bin\Release\citelao.SystrayIcon.0.1.0.nupkg --api-key $apiKey --source https://int.nugettest.org
 ```
+
+### Versioning notes
+
+* Nerdbank.GitVersioning provides the package and assembly versions from `version.json`. The `version` property controls the first three digits (major/minor/patch). The build height becomes the fourth component automatically so you do not need to edit it manually.
+* Non-`main` branches (e.g. `dev`) publish prerelease builds that include a `-dev` suffix before the commit hash for clarity.
+* Nerdbank.GitVersioning can automate release version bumps via the [`nbgv prepare-release`](https://dotnet.github.io/Nerdbank.GitVersioning/docs/nbgv-cli.html#prepare-release) command. TODO: evaluate wiring that into our release flow so merges to `main` automatically advance the base version.
 
 ## TODO
 

--- a/systray/systray.csproj
+++ b/systray/systray.csproj
@@ -19,7 +19,6 @@
    -->
   <PropertyGroup>
     <PackageId>citelao.SystrayIcon</PackageId>
-    <Version>0.1.3.0</Version>
     <Authors>Ben Stolovitz (citelao)</Authors>
 
     <IsAotCompatible>true</IsAotCompatible>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.1.3",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/tags/v\\d+(?:\\.\\d+)?$"
+  ],
+  "gitCommitIdPrefix": "dev",
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add repository-wide Nerdbank.GitVersioning configuration and package reference
- remove the manually maintained `<Version>` from the systray project so builds pick up Git-derived versions
- document the new versioning workflow and changelog updates, including the dev prerelease suffix

## Testing
- dotnet --version *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed16f816f483338b4cd27e6c12e8ac