### PR TITLE
[Doom] Fix compilation on ARM (remove arch-specific code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * META: Add basic PR validation.
 * META: Add NerdBank.GitVersioning for automatic version management.
 * FEATURE: Add context menu helpers, to make it a bit easier to make a well-behaved context menu.
+* BUG: Fixed Doom running on ARM.
 
 ## v0.1.3
 * BUG: Fixed an issue where construction failures in `TrayIcon` crashed the host HWND.

--- a/systray_doom/NativeMethods.txt
+++ b/systray_doom/NativeMethods.txt
@@ -1,7 +1,3 @@
-Shell_NotifyIcon
-NOTIFYICON_VERSION_4
-NOTIFY_ICON_DATA_FLAGS
-
 LoadIcon
 CreateIcon
 DestroyIcon
@@ -33,8 +29,6 @@ GetModuleHandle
 LoadCursor
 DefWindowProc
 
-GetWindowLongPtr
-SetWindowLongPtr
 WINDOW_LONG_PTR_INDEX
 CallWindowProc
 

--- a/systray_doom/WindowMessageHandler.cs
+++ b/systray_doom/WindowMessageHandler.cs
@@ -16,14 +16,14 @@ internal class WindowMessageHandler
                 {
                     var createStruct = (CREATESTRUCTW*)lParam.Value;
                     var data = (Data*)createStruct->lpCreateParams;
-                    PInvoke.SetWindowLongPtr(hwnd, WINDOW_LONG_PTR_INDEX.GWLP_USERDATA, (nint)data);
+                    Systray.NativeTypes.PInvokeCore.SetWindowLongPtr(new Systray.NativeTypes.NoReleaseHwnd(hwnd.Value), (int)WINDOW_LONG_PTR_INDEX.GWLP_USERDATA, (nint)data);
                 }
                 return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
 
             default:
                 unsafe
                 {
-                    var data = (Data*)PInvoke.GetWindowLongPtr(hwnd, WINDOW_LONG_PTR_INDEX.GWLP_USERDATA);
+                    var data = (Data*)Systray.NativeTypes.PInvokeCore.GetWindowLongPtr(new Systray.NativeTypes.NoReleaseHwnd(hwnd.Value), (int)WINDOW_LONG_PTR_INDEX.GWLP_USERDATA);
                     if (data != null)
                     {
                         var id = data->ID;

--- a/systray_doom/systray_doom.csproj
+++ b/systray_doom/systray_doom.csproj
@@ -16,15 +16,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!--
-      The Shell_NotifyIcon APIs are platform-specific (and don't support the
-      AnyCpu build). So specify a specific platform target here. We then kick
-      off another build later for x86.
-
-      https://github.com/microsoft/CsWin32/discussions/592
-    -->
-    <PlatformTarget>x64</PlatformTarget>
-
-    <!--
       Set the assembly title. This is used to group apps in Task Manager.
 
       Look in the Details pane of the Properties page for the exe.
@@ -36,15 +27,6 @@
     <AssemblyTitle>Systray Doom EXE</AssemblyTitle>
     <Product>Systray Doom</Product>
   </PropertyGroup>
-
-  <!--
-    Kick off another build for x86.
-
-    https://stackoverflow.com/a/1580825/788168
-  -->
-  <Target Name="AfterBuild">
-    <MSBuild Condition=" '$(Platform)' == 'x86' " Projects="$(MSBuildProjectFile)" Properties="Platform=x64;PlatFormTarget=x64" RunEachTargetSeparately="true" />
-  </Target>
 
   <!-- Build Rust -->
   <!-- TODO: avoid running if the DLL is up to date? -->


### PR DESCRIPTION
Today, the app doesn't run on ARM. This fixes the app to run on ARM.

## What changed?

* Removed arch-specific PInvokes.
* Replaced with `PInvokeCore` from the library.
* Removed multi-arch compilation workaround.

## How tested?

* [x] Launches on ARM.